### PR TITLE
Use Ubuntu as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM 		progrium/busybox
-MAINTAINER 	Jeff Lindsay <progrium@gmail.com>
+FROM ubuntu:14.04
+
+RUN apt-get update \
+  && apt-get install -y ca-certificates curl unzip \
+  && apt-get purge -y --auto-remove
 
 ADD https://dl.bintray.com/mitchellh/consul/0.5.0_linux_amd64.zip /tmp/consul.zip
 RUN cd /bin && unzip /tmp/consul.zip && chmod +x /bin/consul && rm /tmp/consul.zip
@@ -9,11 +12,6 @@ RUN mkdir /ui && cd /ui && unzip /tmp/webui.zip && rm /tmp/webui.zip && mv dist/
 
 ADD https://get.docker.io/builds/Linux/x86_64/docker-1.5.0 /bin/docker
 RUN chmod +x /bin/docker
-
-RUN opkg-install curl bash ca-certificates
-
-RUN cat /etc/ssl/certs/*.crt > /etc/ssl/certs/ca-certificates.crt && \
-    sed -i -r '/^#.+/d' /etc/ssl/certs/ca-certificates.crt
 
 ADD ./config /config/
 ONBUILD ADD ./config /config/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN cd /bin && unzip /tmp/consul.zip && chmod +x /bin/consul && rm /tmp/consul.z
 ADD https://dl.bintray.com/mitchellh/consul/0.5.0_web_ui.zip /tmp/webui.zip
 RUN mkdir /ui && cd /ui && unzip /tmp/webui.zip && rm /tmp/webui.zip && mv dist/* . && rm -rf dist
 
-ADD https://get.docker.io/builds/Linux/x86_64/docker-1.5.0 /bin/docker
+ADD https://get.docker.io/builds/Linux/x86_64/docker-1.3.1 /bin/docker
 RUN chmod +x /bin/docker
 
 ADD ./config /config/


### PR DESCRIPTION
@bellycard/jam-band, this along with the upstream changes in https://github.com/bellycard/docker-consul/pull/3 will bring us up to Consul 0.5.0. We also moved the base image to Ubuntu, so we can use `consul exec` with a full Linux distro. I tested these changes locally with Jockey and was able to deploy.
